### PR TITLE
Exclude bot users from matchmaking

### DIFF
--- a/app/lib/slack/loads_slack_channel_members.rb
+++ b/app/lib/slack/loads_slack_channel_members.rb
@@ -3,7 +3,15 @@ module Slack
     def call(channel:)
       response = ClientWrapper.client.conversations_members(channel: channel, limit: 1000)
 
-      (response&.members || [])
+      (response&.members || []).intersection(eligible_user_ids)
+    end
+
+    private
+
+    def eligible_user_ids
+      response = ClientWrapper.client.users_list
+
+      (response&.members || []).reject { |u| u.is_bot }.map(&:id)
     end
   end
 end

--- a/spec/lib/slack/loads_slack_channel_members_spec.rb
+++ b/spec/lib/slack/loads_slack_channel_members_spec.rb
@@ -9,12 +9,23 @@ RSpec.describe Slack::LoadsSlackChannelMembers do
   end
 
   it "loads members found in a channel" do
-    slack_members = [
-      "USER_ID_1",
-      "USER_ID_2",
-      "USER_ID_3"
+    all_slack_users = [
+      Slack::Messages::Message.new(id: "USER_ID_1"),
+      Slack::Messages::Message.new(id: "USER_ID_2"),
+      Slack::Messages::Message.new(id: "USER_ID_3"),
+      Slack::Messages::Message.new(id: "USER_ID_4"),
+      Slack::Messages::Message.new(id: "USER_ID_5")
     ]
 
+    slack_members = [
+      "USER_ID_1",
+      "USER_ID_3",
+      "USER_ID_5"
+    ]
+
+    expect(@slack_client).to receive(:users_list) {
+      Slack::Messages::Message.new(ok: true, members: all_slack_users)
+    }
     expect(@slack_client).to receive(:conversations_members).with(channel: "CHANNEL_ID", limit: 1000) {
       Slack::Messages::Message.new(ok: true, members: slack_members)
     }
@@ -22,5 +33,23 @@ RSpec.describe Slack::LoadsSlackChannelMembers do
     members = subject.call(channel: "CHANNEL_ID")
 
     expect(members).to eq(slack_members)
+  end
+
+  it "excludes bots from the returned users" do
+    slack_user = Slack::Messages::Message.new(id: "USER_ID", is_bot: false)
+    slack_app = Slack::Messages::Message.new(id: "APP_ID", is_bot: true)
+
+    slack_members = ["USER_ID", "APP_ID"]
+
+    expect(@slack_client).to receive(:users_list) {
+      Slack::Messages::Message.new(ok: true, members: [slack_user, slack_app])
+    }
+    expect(@slack_client).to receive(:conversations_members).with(channel: "CHANNEL_ID", limit: 1000) {
+      Slack::Messages::Message.new(ok: true, members: slack_members)
+    }
+
+    members = subject.call(channel: "CHANNEL_ID")
+
+    expect(members).to eq(["USER_ID"])
   end
 end


### PR DESCRIPTION
Fixes #15

This refactors the channel member loading to take into account user filtering. Looking back through the existing code, I think this was always a bug; we simply never paid much attention to it if it did happen.