### PR TITLE
Add config for Coffee Time and Q-Branch groupings.

### DIFF
--- a/config/matchmaking.yml
+++ b/config/matchmaking.yml
@@ -1,4 +1,14 @@
 default: &default
+  coffee_time:
+    active: true
+    channel: rotating-coffee-time
+    schedule: daily
+    size: 2
+  q_branch:
+    active: true
+    channel: rotating-q-branch
+    schedule: daily
+    size: 2
   rotating_brunch:
     active: true
     channel: rotating-brunch
@@ -13,4 +23,3 @@ test:
 
 production:
   <<: *default
-


### PR DESCRIPTION
This adds configuration blocks for Q-Branch and Coffee Time

These are for testing so the frequency is set to Daily to get them to run tomorrow. It'll run every day so a followup PR will be opened tomorrow set them to weekly and disable them until we're ready to disable matchmaking in Present. We'll shoot to disable present and make these configs live for Jan 1, 2022.