### PR TITLE
[fix] - Ensure participants are matched exactly once when determining matches

### DIFF
--- a/app/lib/matchmaking/determines_matches.rb
+++ b/app/lib/matchmaking/determines_matches.rb
@@ -88,7 +88,7 @@ module Matchmaking
           break
         end
 
-        all_previously_eligible_candidates += candidates_for_score.flatten.compact
+        all_previously_eligible_candidates += candidates_for_score.flatten.compact.intersection(@unmatched_participants.map(&:id))
       end
 
       if chosen.nil? && (chosen = choose_candidate(all_previously_eligible_candidates)).nil?

--- a/spec/lib/matchmaking/determines_matches_spec.rb
+++ b/spec/lib/matchmaking/determines_matches_spec.rb
@@ -148,5 +148,118 @@ RSpec.describe Matchmaking::DeterminesMatches, type: :matchmaking do
         Matchmaking::Match.new(grouping: "test", members: ["USER_ID_1", "USER_ID_2", "USER_ID_4"])
       ])
     end
+
+    it "ensures all participants are matched exactly once on the first run" do
+      participants = new_participants(
+        ids: ["USER_ID_01", "USER_ID_02", "USER_ID_03", "USER_ID_04", "USER_ID_05", "USER_ID_06", "USER_ID_07", "USER_ID_08", "USER_ID_09", "USER_ID_10"]
+      )
+
+      matches = subject.call(grouping: "test", participants: participants)
+
+      expect(matches.map(&:members).flatten.uniq.size).to eq(10)
+      expect(matches).to eq([
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_05", "USER_ID_06", "USER_ID_08", "USER_ID_09"]),
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_03", "USER_ID_04", "USER_ID_10"]),
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_01", "USER_ID_02", "USER_ID_07"])
+      ])
+    end
+
+    it "ensures all participants are matched exactly once on a subsequent run when historical matches exist" do
+      five_six_eight_nine = create_historical_match(grouping: "test", members: ["USER_ID_05", "USER_ID_06", "USER_ID_08", "USER_ID_09"])
+      three_four_ten = create_historical_match(grouping: "test", members: ["USER_ID_03", "USER_ID_04", "USER_ID_10"])
+      one_two_seven = create_historical_match(grouping: "test", members: ["USER_ID_01", "USER_ID_02", "USER_ID_07"])
+
+      participants = [
+        new_participant(
+          id: "USER_ID_01",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_03", "USER_ID_04", "USER_ID_05", "USER_ID_06", "USER_ID_08", "USER_ID_09", "USER_ID_10"],
+            1 => ["USER_ID_02", "USER_ID_07"]
+          }),
+          historical_matches: [one_two_seven]
+        ),
+        new_participant(
+          id: "USER_ID_02",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_03", "USER_ID_04", "USER_ID_05", "USER_ID_06", "USER_ID_08", "USER_ID_09", "USER_ID_10"],
+            1 => ["USER_ID_01", "USER_ID_07"]
+          }),
+          historical_matches: [one_two_seven]
+        ),
+        new_participant(
+          id: "USER_ID_03",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_05", "USER_ID_06", "USER_ID_07", "USER_ID_08", "USER_ID_09"],
+            1 => ["USER_ID_04", "USER_ID_10"]
+          }),
+          historical_matches: [three_four_ten]
+        ),
+        new_participant(
+          id: "USER_ID_04",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_05", "USER_ID_06", "USER_ID_07", "USER_ID_08", "USER_ID_09"],
+            1 => ["USER_ID_03", "USER_ID_10"]
+          }),
+          historical_matches: [three_four_ten]
+        ),
+        new_participant(
+          id: "USER_ID_05",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_03", "USER_ID_04", "USER_ID_07", "USER_ID_10"],
+            1 => ["USER_ID_06", "USER_ID_08", "USER_ID_09"]
+          }),
+          historical_matches: [five_six_eight_nine]
+        ),
+        new_participant(
+          id: "USER_ID_06",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_03", "USER_ID_04", "USER_ID_07", "USER_ID_10"],
+            1 => ["USER_ID_05", "USER_ID_08", "USER_ID_09"]
+          }),
+          historical_matches: [five_six_eight_nine]
+        ),
+        new_participant(
+          id: "USER_ID_07",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_03", "USER_ID_04", "USER_ID_05", "USER_ID_06", "USER_ID_08", "USER_ID_09", "USER_ID_10"],
+            1 => ["USER_ID_01", "USER_ID_02"]
+          }),
+          historical_matches: [one_two_seven]
+        ),
+        new_participant(
+          id: "USER_ID_08",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_03", "USER_ID_04", "USER_ID_07", "USER_ID_10"],
+            1 => ["USER_ID_05", "USER_ID_06", "USER_ID_09"]
+          }),
+          historical_matches: [five_six_eight_nine]
+        ),
+        new_participant(
+          id: "USER_ID_09",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_03", "USER_ID_04", "USER_ID_07", "USER_ID_10"],
+            1 => ["USER_ID_05", "USER_ID_06", "USER_ID_08"]
+          }),
+          historical_matches: [five_six_eight_nine]
+        ),
+        new_participant(
+          id: "USER_ID_10",
+          match_candidates: new_candidates_by_score({
+            0 => ["USER_ID_01", "USER_ID_02", "USER_ID_05", "USER_ID_06", "USER_ID_07", "USER_ID_08", "USER_ID_09"],
+            1 => ["USER_ID_03", "USER_ID_04"]
+          }),
+          historical_matches: [three_four_ten]
+        )
+      ]
+
+      matches = subject.call(grouping: "test", participants: participants)
+
+      expect(matches.map(&:members).flatten.uniq.size).to eq(10)
+      expect(matches).to eq([
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_02", "USER_ID_06", "USER_ID_09", "USER_ID_10"]),
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_01", "USER_ID_04", "USER_ID_05"]),
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_03", "USER_ID_07", "USER_ID_08"])
+      ])
+    end
   end
 end

--- a/spec/support/matchmaking_helpers.rb
+++ b/spec/support/matchmaking_helpers.rb
@@ -26,4 +26,10 @@ module MatchmakingHelpers
   def new_match(grouping:, members:)
     Matchmaking::Match.new(grouping: grouping, members: members)
   end
+
+  def new_candidates_by_score(scored_candidates)
+    scored_candidates.reduce([]) { |memo, (score, candidates)|
+      memo.concat(candidates.map { |id| new_match_candidate(id: id, score: score) })
+    }
+  end
 end


### PR DESCRIPTION
Fixes #28

This particular issue required 4 criteria to be met for it it to possibly occur

1. The grouping size has to be more than 2
2. There are already at least 2 participants chosen for a specific match
3. There are historical matches from a previous run
4. The chosen participants within a particular match have no candidates in common

When all of that is met, it was possible for someone to be selected again because the code wasn't filtering down to only the unmatched remaining participants. It may sound like an edge case, but it really is more of a late stage bug within the matching logic, so it was possible to happen every time.

